### PR TITLE
Add extra formatting for <dt> and <dd> elements

### DIFF
--- a/determined_ai_sphinx_theme/static/css/theme.css
+++ b/determined_ai_sphinx_theme/static/css/theme.css
@@ -10081,6 +10081,10 @@ article.determined-ai-article dl {
 }
 article.determined-ai-article dl dt {
   margin-bottom: 0.75rem;
+  font-weight: 900;
+}
+article.determined-ai-article dl dd {
+  margin-left: 1.25rem;
 }
 article.determined-ai-article pre {
   margin-bottom: 2.5rem;

--- a/scss/shared/_article.scss
+++ b/scss/shared/_article.scss
@@ -107,6 +107,11 @@ article.determined-ai-article {
 
   dl dt {
     margin-bottom: rem(12px);
+    font-weight: 900;
+  }
+
+  dl dd {
+    margin-left: rem(20px);
   }
 
   pre {


### PR DESCRIPTION
This enables nice things like this using reST's [definition list syntax](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#definition-lists):

![2020-04-03-14-29-19 738042691](https://user-images.githubusercontent.com/596106/78406484-90619280-75b7-11ea-9d56-2b5c7c7a9c1a.png)

I haven't included the changes to the output CSS theme file because my build somehow produced a minified version, which doesn't match what's there now... Would appreciate guidance on how to make that not happen (or feel free to add the changes to the PR yourself).