### PR TITLE
Make download links visible

### DIFF
--- a/determined_ai_sphinx_theme/static/css/theme.css
+++ b/determined_ai_sphinx_theme/static/css/theme.css
@@ -10795,7 +10795,7 @@ article.determined-ai-article .error .admonition-title {
   background: #cc2f90;
 }
 article.determined-ai-article .sphx-glr-download-link-note.admonition.note,
-article.determined-ai-article .reference.download.internal, article.determined-ai-article .sphx-glr-signature {
+article.determined-ai-article .sphx-glr-signature {
   display: none;
 }
 article.determined-ai-article .admonition > p:last-of-type {

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -635,7 +635,7 @@ article.determined-ai-article {
   }
 
   .sphx-glr-download-link-note.admonition.note,
-  .reference.download.internal, .sphx-glr-signature {
+  .sphx-glr-signature {
     display: none;
   }
 


### PR DESCRIPTION
I worry that this will have unintended effects somewhere, but at least the download links for examples are visible again.

![2020-04-04-21-49-50 385085842](https://user-images.githubusercontent.com/596106/78467119-3bf50a80-76be-11ea-95a6-ab83ef0b8905.png)
![2020-04-04-21-49-11 206411896](https://user-images.githubusercontent.com/596106/78467121-3dbece00-76be-11ea-8f34-da83de521b46.png)
