### PR TITLE
fix: prevent left menu from shrinking beyond 20%

### DIFF
--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -160,6 +160,7 @@ body {
 
 .determined-ai-left-menu {
   flex-basis: 100%;
+  flex-shrink: 0;
   display: none;
   position: absolute;
   width: 100%;


### PR DESCRIPTION
The left hand side menu was shrinking based on how much the content grew. Adjusted the style to prevent it from collapsing beyond width of 20%.