### PR TITLE
fix: improve list spacing

### DIFF
--- a/determined_ai_sphinx_theme/static/css/theme.css
+++ b/determined_ai_sphinx_theme/static/css/theme.css
@@ -10063,7 +10063,7 @@ article.determined-ai-article table.docutils.field-list td.field-body p:last-of-
 }
 article.determined-ai-article ul,
 article.determined-ai-article ol {
-  margin: 1.5rem 0 3.125rem 0;
+  margin: 0 0 1.125rem 0;
 }
 @media screen and (min-width: 768px) {
   article.determined-ai-article ul,
@@ -10303,7 +10303,6 @@ a:visited.has-code span {
 article.determined-ai-article ul,
 article.determined-ai-article ol {
   padding-left: 1.875rem;
-  margin: 0;
 }
 article.determined-ai-article ul li,
 article.determined-ai-article ol li {
@@ -11176,9 +11175,6 @@ body {
   .determined-ai-content-left {
     padding: 1.875rem calc(25% + 1.875rem) 1.875rem 1.875rem;
   }
-}
-.determined-ai-content-left .main-content ul.simple {
-  padding-bottom: 1.25rem;
 }
 .determined-ai-content-left .main-content .note:nth-child(1), .determined-ai-content-left .main-content .warning:nth-child(1) {
   margin-top: 0;

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -243,7 +243,6 @@ article.determined-ai-article {
   ul,
   ol {
     padding-left: rem(30px);
-    margin: 0;
 
     li {
       margin: 0;

--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -68,9 +68,6 @@ body {
   }
 
   .main-content {
-    ul.simple {
-      padding-bottom: rem(20px);
-    }
     .note, .warning {
       &:nth-child(1) {
         margin-top: 0;

--- a/scss/shared/_article.scss
+++ b/scss/shared/_article.scss
@@ -90,7 +90,7 @@ article.determined-ai-article {
 
   ul,
   ol{
-    margin: rem(24px) 0 rem(50px) 0;
+    margin: 0 0 rem(18px) 0;
 
     @include desktop {
       padding-left: rem(100px);


### PR DESCRIPTION
Remove a redundant rule (`margin: 0`) and tweak some spacing so that lists act more like paragraphs and fit more naturally among them.

----

![1](https://user-images.githubusercontent.com/596106/78959039-9adfc880-7a9e-11ea-8fbf-d9164200ac9c.png)

----

![2](https://user-images.githubusercontent.com/596106/78959043-9d422280-7a9e-11ea-83b2-4104f3024533.png)

----

![3](https://user-images.githubusercontent.com/596106/78958915-56542d00-7a9e-11ea-8b05-fccc83fe398a.png)

----

![4](https://user-images.githubusercontent.com/596106/78958919-581df080-7a9e-11ea-83aa-3f2d52f2b70d.png)

----

![5](https://user-images.githubusercontent.com/596106/78958922-5a804a80-7a9e-11ea-8b85-4425325ad2ed.png)

----

![6](https://user-images.githubusercontent.com/596106/78959201-0de93f00-7a9f-11ea-8a22-f9049c05d1e9.png)
