### PR TITLE
Disable download links in Sphinx gallery.

### DIFF
--- a/determined_ai_sphinx_theme/static/css/theme.css
+++ b/determined_ai_sphinx_theme/static/css/theme.css
@@ -11810,6 +11810,13 @@ body {
   border-bottom: 1px solid #e2e2e2;
 }
 
+/* Sphinx gallery generates download links with fixed paths that assume a doc
+   build structure different than ours. This CSS rule hides the sphinx-generated
+   download galleries in HTML so that we don't display broken links */
+.sphx-glr-download {
+  display: none;
+}
+
 /*!
  * Hamburgers
  * @description Tasty CSS-animated hamburgers

--- a/scss/_sphinx_gallery_override.scss
+++ b/scss/_sphinx_gallery_override.scss
@@ -1,0 +1,6 @@
+/* Sphinx gallery generates download links with fixed paths that assume a doc
+   build structure different than ours. This CSS rule hides the sphinx-generated
+   download galleries in HTML so that we don't display broken links */
+.sphx-glr-download {
+  display: none;
+}

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -12,5 +12,6 @@
 
 @import "sphinx_base";
 @import "sphinx_layout";
+@import "sphinx_gallery_override";
 
 @import "hamburger";


### PR DESCRIPTION
https://github.com/determined-ai/determined/pull/170 introduces sphinx
gallery as a tool to unify our tutorials and example code. However,
the download links that sphinx gallery generates assumes a certain
directory structure our sphinx doc build does not conform to.